### PR TITLE
updating to return the share_URL

### DIFF
--- a/opened.go
+++ b/opened.go
@@ -28,7 +28,7 @@ import (
 type Resource struct {
 	ID             int
 	Title          sql.NullString
-	URL            sql.NullString
+	URL            sql.NullString `db:"share_url"
 	PublisherID    sql.NullInt64 `db:"publisher_id"`
 	ContributionID sql.NullInt64 `db:"contribution_id"`
 	Description    sql.NullString


### PR DESCRIPTION
adding the ability to return the URL from a query of the resource API

I'm wondering if I should be using this package or, better to hit the API directly
